### PR TITLE
Upload bosh release sources to s3

### DIFF
--- a/pipelines/release-images-cf-deployment/pipeline.yml
+++ b/pipelines/release-images-cf-deployment/pipeline.yml
@@ -39,6 +39,14 @@ resources:
     access_key_id: ((s3.accessKey))
     secret_access_key: ((s3.secretKey))
     versioned_file: ((stemcell-version-file))
+- name: s3.kubecf-sources
+  type: s3
+  source:
+    regexp: bosh-releases/(.*)\.tgz
+    bucket: ((kubecf-sources-s3-bucket))
+    region_name: ((kubecf-sources-s3-bucket-region))
+    access_key_id: ((s3.accessKey))
+    secret_access_key: ((s3.secretKey))
 
 jobs:
 <% cf_deployment_tags.each do |cf_deployment_tag| %>
@@ -96,5 +104,9 @@ jobs:
           DOCKER_TEAM_USERNAME: ((dockerhub.username))
           DOCKER_TEAM_PASSWORD_RW: ((dockerhub.password))
         file: ci/pipelines/release-images-cf-deployment/tasks/build.yml
+      - put: s3.kubecf-sources
+        params:
+          file: s3.kubecf-sources/*
+          acl: public-read
   <% end %>
 <% end %>

--- a/pipelines/release-images-cf-deployment/tasks/build.yml
+++ b/pipelines/release-images-cf-deployment/tasks/build.yml
@@ -11,6 +11,8 @@ inputs:
 - name: cf-deployment
 - name: s3.stemcell-version
 - name: s3.fissile-linux
+outputs:
+- name: s3.kubecf-sources
 params:
   STEMCELL_OS:
   STEMCELL_REPOSITORY:

--- a/pipelines/release-images-cf-deployment/tasks/build_release.sh
+++ b/pipelines/release-images-cf-deployment/tasks/build_release.sh
@@ -48,6 +48,9 @@ function build_release() {
   if curl --silent -u "${docker_creds_string}" "https://"${docker_registry}"/v2/"${docker_organization}"/"${release_name}"/manifests/"${built_image_tag}"" | jq '.errors[0].code' | grep -q null; then
     echo -e "Skipping push for ${GREEN}${built_image}${NC} as it is already present in the registry..."
   else
+      # Download source tarball so that it can be stored later on
+      curl -L -o "s3.kubecf-sources/${release_name}-${release_version}.tgz" "${release_url}"
+
       # Build the release image.
       fissile build release-images "${build_args[@]}"
 

--- a/pipelines/release-images-cf-deployment/tasks/prepare_build.sh
+++ b/pipelines/release-images-cf-deployment/tasks/prepare_build.sh
@@ -10,15 +10,15 @@ failed=false
 
 # Find releases which are not covered by the pipeline yet
 new_releases=$(comm -23 <(echo $manifest_releases | tr " " "\n") <(echo $RELEASES | tr " " "\n") | tr -d '[:space:]')
-if [ -z "$new_releases" ]; then
-  echo "There are new release which are not covered by the pipeline yet: $new_releases"
+if [ -n "$new_releases" ]; then
+  echo "There are new releases which are not covered by the pipeline yet: $new_releases"
   failed=true
 fi
 
 # Find releases which are no longer part of cf-deployment
 obsolete_releases=$(comm -13 <(echo $manifest_releases | tr " " "\n") <(echo $RELEASES | tr " " "\n") | tr -d '[:space:]')
 
-if [ -z "$obsolete_releases" ]; then
+if [ -n "$obsolete_releases" ]; then
   echo "There are releases which are no longer part of cf-deployment: $obsolete_releases"
   failed=true
 fi

--- a/pipelines/release-images-cf-deployment/vars.yml
+++ b/pipelines/release-images-cf-deployment/vars.yml
@@ -11,5 +11,7 @@ stemcell-repository: splatform/fissile-stemcell-sle
 stemcell-versions-s3-bucket: cf-operators
 stemcell-version-file: fissile-stemcell-versions/fissile-stemcell-sle15-version
 stemcell-s3-bucket-region: us-east-1
+kubecf-sources-s3-bucket: kubecf-sources
+kubecf-sources-s3-bucket-region: us-east-1
 docker-registry: docker.io
 docker-organization: cfcontainerization

--- a/pipelines/release-images/pipeline.yml
+++ b/pipelines/release-images/pipeline.yml
@@ -51,6 +51,15 @@ resources:
     secret_access_key: ((s3.secretKey))
     versioned_file: fissile-stemcell-versions/fissile-stemcell-sle15-version
 
+- name: s3.kubecf-sources
+  type: s3
+  source:
+    regexp: bosh-releases/(.*)\.tgz
+    bucket: ((kubecf-sources-s3-bucket))
+    region_name: ((kubecf-sources-s3-bucket-region))
+    access_key_id: ((s3.accessKey))
+    secret_access_key: ((s3.secretKey))
+
 jobs:
 <% (releases + s3_releases).each do |release| %>
 - name: build-<%= release[:name] %>
@@ -81,4 +90,8 @@ jobs:
         DOCKER_TEAM_PASSWORD_RW: ((dockerhub.password))
         REGISTRY_NAMESPACE: "cfcontainerization"
       file: ci/pipelines/release-images/tasks/build.yml
+    - put: s3.kubecf-sources
+      params:
+        file: s3.kubecf-sources/*
+        acl: public-read
 <% end %>

--- a/pipelines/release-images/tasks/build.sh
+++ b/pipelines/release-images/tasks/build.sh
@@ -19,6 +19,7 @@ tar xfv fissile-*.tgz
 popd
 
 VERSION=$(cat release/version)
+URL=$(cat release/url)
 
 # Prepare stemcell
 STEMCELL_NAME="${STEMCELL_REPOSITORY}:$(cat s3.stemcell-version/*-version)"
@@ -31,7 +32,10 @@ else
   SHA1=$(cat release/sha1)
 fi
 
-s3.fissile-linux/fissile build release-images --stemcell="${STEMCELL_NAME}" --name="${RELEASE_NAME}" --version="${VERSION}" --sha1="$SHA1" --url="$(cat release/url)"
+# Download source tarball so that it can be stored later on
+curl -L -o "s3.kubecf-sources/${RELEASE_NAME}-${VERSION}.tgz" "${URL}"
+
+s3.fissile-linux/fissile build release-images --stemcell="${STEMCELL_NAME}" --name="${RELEASE_NAME}" --version="${VERSION}" --sha1="$SHA1" --url="${URL}"
 
 BUILT_IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v "$STEMCELL_REPOSITORY" | head -1)
 docker tag "${BUILT_IMAGE}" "${REGISTRY_NAMESPACE}/${BUILT_IMAGE}"

--- a/pipelines/release-images/tasks/build.yml
+++ b/pipelines/release-images/tasks/build.yml
@@ -10,6 +10,8 @@ inputs:
 - name: s3.stemcell-version
 - name: ci
 - name: s3.fissile-linux
+outputs:
+- name: s3.kubecf-sources
 params:
   STEMCELL_REPOSITORY:
   RELEASE_NAME:

--- a/pipelines/release-images/vars.yml
+++ b/pipelines/release-images/vars.yml
@@ -4,3 +4,5 @@ docker-organization: cfcontainerization
 s3-bucket: cf-opensusefs2
 versions-s3-bucket: cf-operators
 stemcell-repository: splatform/fissile-stemcell-sle
+kubecf-sources-s3-bucket: kubecf-sources
+kubecf-sources-s3-bucket-region: us-east-1


### PR DESCRIPTION
This ensures that we can always refer back to the sources when needed.