### PR TITLE
Adding explicit check_every config to resources

### DIFF
--- a/pipelines/cf-operator-check/pipeline.yml
+++ b/pipelines/cf-operator-check/pipeline.yml
@@ -12,6 +12,7 @@ resource_types:
 resources:
 - name: src
   type: pull-request
+  check_every: 1m
   webhook_token: ((github.webhook-token))
   source:
     repository: ((pr-repo))

--- a/pipelines/cf-operator-nightly/pipeline.yml
+++ b/pipelines/cf-operator-nightly/pipeline.yml
@@ -17,6 +17,7 @@ resources:
     password: ((dockerhub.password))
 - name: 12h
   type: time
+  check_every: 10m
   source:
     interval: 12h
 

--- a/pipelines/cf-operator-release/pipeline.yml
+++ b/pipelines/cf-operator-release/pipeline.yml
@@ -6,6 +6,7 @@
 resources:
 - name: src
   type: git
+  check_every: 1m
   source:
     uri: ((src-repo))
     branch: <%= branch %>

--- a/pipelines/cf-operator-testing-image/pipeline.yml
+++ b/pipelines/cf-operator-testing-image/pipeline.yml
@@ -8,12 +8,14 @@ resources:
     paths: [bosh-releases/*, pipelines/*]
 - name: s3.fissile-linux
   type: s3
+  check_every: 1m
   source:
     bucket: ((s3-bucket))
     private: true
     regexp: fissile/develop/fissile-(.*)\.tgz
 - name: s3.fissile-stemcell-version
   type: s3
+  check_every: 1m
   source:
     bucket: ((versions-s3-bucket))
     access_key_id: ((s3.accessKey))
@@ -22,6 +24,7 @@ resources:
 <% releases.each do |release| %>
 - name: s3.final-release-<%= release %>
   type: s3
+  check_every: 5m
   source:
     bucket: ((versions-s3-bucket))
     regexp: <%= release %>-release-(.*).tgz

--- a/pipelines/images/pipeline.yml
+++ b/pipelines/images/pipeline.yml
@@ -1,6 +1,7 @@
 resources:
 - name: ci
   type: git
+  check_every: 1m
   source:
     uri: ((ci-repo))
     branch: ((ci-branch))

--- a/pipelines/release-images-cf-deployment/pipeline.yml
+++ b/pipelines/release-images-cf-deployment/pipeline.yml
@@ -37,12 +37,14 @@ resources:
 <% end %>
 - name: s3.fissile-linux
   type: s3
+  check_every: 1m
   source:
     bucket: ((fissile-linux-s3-bucket))
     private: true
     regexp: fissile/develop/fissile-(.*)\.tgz
 - name: s3.fissile-stemcell-version
   type: s3
+  check_every: 1m
   source:
     bucket: ((stemcell-versions-s3-bucket))
     region_name: ((stemcell-s3-bucket-region))

--- a/pipelines/release-images/pipeline.yml
+++ b/pipelines/release-images/pipeline.yml
@@ -63,18 +63,21 @@ resources:
 <% releases.each do |release| %>
 - name: <%= release[:name] %>-release
   type: bosh-io-release
+  check_every: 1m
   source:
     repository: <%= release[:organization] %>/<%= release[:name] %>-release
 <% end %>
 <% s3_releases.each do |release| %>
 - name: <%= release[:name] %>-release
   type: s3
+  check_every: 5m
   source:
     bucket: <%= release[:bucket] %>
     regexp: <%= release[:name] %>-release-(.*).tgz
 <% end %>
 - name: s3.fissile-linux
   type: s3
+  check_every: 1m
   source:
     bucket: ((s3-bucket))
     private: true
@@ -82,6 +85,7 @@ resources:
 
 - name: s3.fissile-stemcell-sle-version
   type: s3
+  check_every: 1m
   source:
     bucket: ((versions-s3-bucket))
     access_key_id: ((s3.accessKey))


### PR DESCRIPTION
We'll increase the default check intervall to more than one minute, to
reduce the number of running containers.
Concourse will force a check of resources, when actually running a task.
However some resources are used to trigger pipelines and should be
checked more often.