### PR TITLE
Check pipeline reports success depending on  git changes

### DIFF
--- a/pipelines/cf-operator-check/pipeline.yml
+++ b/pipelines/cf-operator-check/pipeline.yml
@@ -60,6 +60,7 @@ jobs:
       file: ci/pipelines/tasks/vet.yml
       params:
         GOPROXY: ((goproxy))
+        SUCCEED_UNLESS_CHANGES_CONTAIN: '.*\.go$'
     on_failure:
       put: status
       params:
@@ -93,6 +94,7 @@ jobs:
       file: ci/pipelines/tasks/lint.yml
       params:
         GOPROXY: ((goproxy))
+        SUCCEED_UNLESS_CHANGES_CONTAIN: '.*\.go$'
     on_failure:
       put: status
       params:
@@ -126,6 +128,7 @@ jobs:
       file: ci/pipelines/tasks/staticcheck.yml
       params:
         GOPROXY: ((goproxy))
+        SUCCEED_UNLESS_CHANGES_CONTAIN: '.*\.go$'
     on_failure:
       put: status
       params:
@@ -167,6 +170,7 @@ jobs:
       file: ci/pipelines/tasks/build.yml
       params:
         GOPROXY: ((goproxy))
+        SUCCEED_UNLESS_CHANGES_BEYOND: '^docs/.*\.md'
     - put: docker.cf-operator-ci
       params:
         build: src
@@ -193,6 +197,7 @@ jobs:
       file: ci/pipelines/tasks/test.yml
       params:
         GOPROXY: ((goproxy))
+        SUCCEED_UNLESS_CHANGES_BEYOND: '^docs/.*\.md'
     - task: test-integration
       params:
         ibmcloud_apikey: ((ibmcloud.key-value))
@@ -206,6 +211,7 @@ jobs:
         DOCKER_IMAGE_REPOSITORY: ((docker-repo))
         GOPROXY: ((goproxy))
         NODES: 6
+        SUCCEED_UNLESS_CHANGES_BEYOND: '^docs/.*\.md'
       file: ci/pipelines/tasks/test-integration.yml
     - task: test-helm-e2e
       params:
@@ -219,6 +225,7 @@ jobs:
         DOCKER_IMAGE_REPOSITORY: ((docker-repo))
         OPERATOR_TEST_STORAGE_CLASS: ((storageclass))
         GOPROXY: ((goproxy))
+        SUCCEED_UNLESS_CHANGES_BEYOND: '^docs/.*\.md'
       file: ci/pipelines/tasks/test-helm-e2e.yml
     on_failure:
       in_parallel:

--- a/pipelines/tasks/build.yml
+++ b/pipelines/tasks/build.yml
@@ -13,4 +13,7 @@ outputs:
 - name: binaries
 - name: docker
 run:
-  path: ci/pipelines/tasks/build.sh
+  path: ci/succeed_unless.sh
+  args:
+    - src/code.cloudfoundry.org/quarks-operator
+    - ci/pipelines/tasks/build.sh

--- a/pipelines/tasks/lint.yml
+++ b/pipelines/tasks/lint.yml
@@ -10,4 +10,7 @@ inputs:
   path: src/code.cloudfoundry.org/quarks-operator
 - name: ci
 run:
-  path: ci/pipelines/tasks/lint.sh
+  path: ci/succeed_unless.sh
+  args:
+    - src/code.cloudfoundry.org/quarks-operator
+    - ci/pipelines/tasks/lint.sh

--- a/pipelines/tasks/staticcheck.yml
+++ b/pipelines/tasks/staticcheck.yml
@@ -10,4 +10,7 @@ inputs:
   path: src/code.cloudfoundry.org/quarks-operator
 - name: ci
 run:
-  path: ci/pipelines/tasks/staticcheck.sh
+  path: ci/succeed_unless.sh
+  args:
+    - src/code.cloudfoundry.org/quarks-operator
+    - ci/pipelines/tasks/staticcheck.sh

--- a/pipelines/tasks/test-helm-e2e.yml
+++ b/pipelines/tasks/test-helm-e2e.yml
@@ -12,4 +12,7 @@ inputs:
 outputs:
 - name: env_dumps
 run:
-  path: ci/pipelines/tasks/test-helm-e2e.sh
+  path: ci/succeed_unless.sh
+  args:
+    - src/code.cloudfoundry.org/quarks-operator
+    - ci/pipelines/tasks/test-helm-e2e.sh

--- a/pipelines/tasks/test-integration.yml
+++ b/pipelines/tasks/test-integration.yml
@@ -15,4 +15,7 @@ outputs:
 - name: code-coverage
 - name: env_dumps
 run:
-  path: ci/pipelines/tasks/test-integration.sh
+  path: ci/succeed_unless.sh
+  args:
+    - src/code.cloudfoundry.org/quarks-operator
+    - ci/pipelines/tasks/test-integration.sh

--- a/pipelines/tasks/test.yml
+++ b/pipelines/tasks/test.yml
@@ -14,4 +14,7 @@ inputs:
 outputs:
 - name: code-coverage
 run:
-  path: ci/pipelines/tasks/test.sh
+  path: ci/succeed_unless.sh
+  args:
+    - src/code.cloudfoundry.org/quarks-operator
+    - ci/pipelines/tasks/test.sh

--- a/pipelines/tasks/vet.yml
+++ b/pipelines/tasks/vet.yml
@@ -10,4 +10,7 @@ inputs:
   path: src/code.cloudfoundry.org/quarks-operator
 - name: ci
 run:
-  path: ci/pipelines/tasks/vet.sh
+  path: ci/succeed_unless.sh
+  args:
+    - src/code.cloudfoundry.org/quarks-operator
+    - ci/pipelines/tasks/vet.sh

--- a/succeed_unless.sh
+++ b/succeed_unless.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e -u -x
+
+usage() {
+  echo "Usage: $0 task.sh git-dir"
+}
+
+succeed_early() {
+  exit 0
+}
+
+
+dir="${1-}"
+if [ -z ${dir+x} ] || [ ! -d "$dir" ]; then
+  echo "missing git dir to check for changes"
+  usage
+  exit 1
+fi
+
+task="${2-}"
+if [ -z ${task+x} ]; then
+  echo "missing task script which is conditionally executed"
+  usage
+  exit 1
+fi
+
+shift 2
+
+pushd "$dir"
+
+# after excluding all lines matching the regex, exit if no lines are left
+if [ ${SUCCEED_UNLESS_CHANGES_BEYOND+x} ]; then
+  lines=$( git diff --name-only HEAD~1 | \
+    grep -E -v "$SUCCEED_UNLESS_CHANGES_BEYOND" )
+  if [ -z "$lines" ]; then
+    succeed_early
+  fi
+fi
+
+# if changes do not include any lines matching the regex, exit early
+if [ ${SUCCEED_UNLESS_CHANGES_CONTAIN+x} ]; then
+  git diff --name-only HEAD~1 | \
+    grep -q -E "$SUCCEED_UNLESS_CHANGES_CONTAIN" || succeed_early
+fi
+
+popd
+
+exec "$task" "$@"


### PR DESCRIPTION
Short-circuit the tests and set the status to success, if the files of the commit match one of the conditions:

* does not contain files outside the regex pattern (`docs/.*md`)
* does not contain any files from the pattern (`.*\.go`)

[#172645334](https://www.pivotaltracker.com/story/show/172645334)