### PR TITLE
Minor changes to pipeline

### DIFF
--- a/pipelines/release-images/pipeline.yml
+++ b/pipelines/release-images/pipeline.yml
@@ -136,9 +136,8 @@ jobs:
 <% (releases + s3_releases).each do |release| %>
 - name: build-<%= release[:name] %>
   plan:
-  - aggregate:
+  - in_parallel:
     - get: ci
-  - aggregate:
     - get: s3.fissile-stemcell-sle-version
       trigger: true
     - get: <%= release[:name] %>-release

--- a/pipelines/release-images/pipeline.yml
+++ b/pipelines/release-images/pipeline.yml
@@ -1,5 +1,36 @@
 <%
-cloudfoundry_releases = %w(binary-buildpack dotnet-core-buildpack go-buildpack java-buildpack nodejs-buildpack php-buildpack python-buildpack ruby-buildpack staticfile-buildpack cf-mysql capi cf-networking cf-smoke-tests cf-syslog-drain cflinuxfs2 cflinuxfs3 diego garden-runc loggregator nats statsd-injector uaa loggregator-agent log-cache bosh-dns-aliases syslog postgres routing nfs-volume)
+cloudfoundry_releases = %w(
+  binary-buildpack
+  dotnet-core-buildpack
+  go-buildpack
+  java-buildpack
+  nodejs-buildpack
+  php-buildpack
+  python-buildpack
+  ruby-buildpack
+  staticfile-buildpack
+
+  bosh-dns-aliases
+  capi
+  cf-mysql
+  cf-networking
+  cf-smoke-tests
+  cf-syslog-drain
+  cflinuxfs2
+  cflinuxfs3
+  diego
+  garden-runc
+  log-cache
+  loggregator
+  loggregator-agent
+  nats
+  nfs-volume
+  postgres
+  routing
+  statsd-injector
+  syslog
+  uaa
+)
 incubator_releases = %w(bpm pxc bits-service app-autoscaler)
 bosh_packages_releases = %w(cf-cli)
 pivotal_cf_releases = %w(credhub)

--- a/pipelines/release-images/pipeline.yml
+++ b/pipelines/release-images/pipeline.yml
@@ -159,7 +159,7 @@ jobs:
         RELEASE_NAME: <%= release[:name] %>
         DOCKER_TEAM_USERNAME: ((dockerhub.username))
         DOCKER_TEAM_PASSWORD_RW: ((dockerhub.password))
-        REGISTRY_NAMESPACE: "cfcontainerization"
+        REGISTRY_NAMESPACE: ((docker-organization))
       file: ci/pipelines/release-images/tasks/build.yml
     - put: s3.kubecf-sources
       params:

--- a/pipelines/release-images/pipeline.yml
+++ b/pipelines/release-images/pipeline.yml
@@ -1,6 +1,6 @@
 <%
-cloudfoundry_releases = %w(binary-buildpack dotnet-core-buildpack go-buildpack java-buildpack nodejs-buildpack php-buildpack python-buildpack ruby-buildpack staticfile-buildpack cf-mysql capi cf-networking cf-smoke-tests cf-syslog-drain cflinuxfs2 cflinuxfs3 diego garden-runc loggregator nats statsd-injector uaa loggregator-agent log-cache bosh-dns-aliases syslog postgres nfs-volume)
-incubator_releases = %w(bpm cf-routing pxc bits-service app-autoscaler)
+cloudfoundry_releases = %w(binary-buildpack dotnet-core-buildpack go-buildpack java-buildpack nodejs-buildpack php-buildpack python-buildpack ruby-buildpack staticfile-buildpack cf-mysql capi cf-networking cf-smoke-tests cf-syslog-drain cflinuxfs2 cflinuxfs3 diego garden-runc loggregator nats statsd-injector uaa loggregator-agent log-cache bosh-dns-aliases syslog postgres routing nfs-volume)
+incubator_releases = %w(bpm pxc bits-service app-autoscaler)
 bosh_packages_releases = %w(cf-cli)
 pivotal_cf_releases = %w(credhub)
 community_releases = %w(eirini-bosh)


### PR DESCRIPTION
I mostly wanted to move the routing release to the non-incubator section: the [incubator releases](https://www.bosh.io/releases/github.com/cloudfoundry-incubator/cf-routing-release?all=1) go up to 0.193.0, but the [non-incubator list](https://www.bosh.io/releases/github.com/cloudfoundry/routing-release?all=1) goes up to 0.201.0.  Also put in various cleanups to make the pipeline easier to test with.  They are all in separate commits, so please mention any specific commits I should drop (or push to my fork directly).