### PR TITLE
Can't skip the build step of pr pipeline

### DIFF
--- a/pipelines/cf-operator-check/pipeline.yml
+++ b/pipelines/cf-operator-check/pipeline.yml
@@ -109,7 +109,6 @@ jobs:
       file: ci/pipelines/tasks/build.yml
       params:
         GOPROXY: ((goproxy))
-        SUCCEED_UNLESS_CHANGES_BEYOND: '^(docs/.*\.md|website/.*|\.github/.*)'
     on_failure:
       put: status
       params:

--- a/pipelines/tasks/build.yml
+++ b/pipelines/tasks/build.yml
@@ -13,7 +13,4 @@ outputs:
 - name: binaries
 - name: docker
 run:
-  path: ci/bin/kurzschluss.rb
-  args:
-    - src/code.cloudfoundry.org/quarks-operator
-    - ci/pipelines/tasks/build.sh
+  path: ci/pipelines/tasks/build.sh


### PR DESCRIPTION
If the step succeeds without building, it can update GH status, but
can't push the image