### PR TITLE
Change coredns image source to dockerhub

### DIFF
--- a/pipelines/cf-operator/pipeline.yml
+++ b/pipelines/cf-operator/pipeline.yml
@@ -27,11 +27,11 @@ resources:
     repository: ((ghcr-repository))
     username: ((github.user))
     password: ((github.access-token-push-quarks))
-- name: docker.coredns
-  type: docker-image
-  check_every: 48h
-  source:
-    repository: ((coredns-repo))
+# - name: docker.coredns
+#   type: docker-image
+#   check_every: 48h
+#   source:
+#     repository: ((coredns-repo))
 - name: s3.cf-operator
   type: s3
   source:
@@ -239,17 +239,17 @@ jobs:
           file: helm-charts/cf-operator-*.tgz
           acl: public-read
 
-- name: create-coredns-pr
-  plan:
-  - in_parallel:
-    - get: ci
-    - get: src
-      passed: [test-integration]
-    - get: docker.coredns
-      trigger: true
-  - task: bump
-    file: ci/pipelines/cf-operator/tasks/create-coredns-pr.yml
-    params:
-      USERNAME: ((github.user))
-      PASSWORD: ((github.password))
-      coredns_repo: ((coredns-repo))
+# - name: create-coredns-pr
+#   plan:
+#   - in_parallel:
+#     - get: ci
+#     - get: src
+#       passed: [test-integration]
+#     - get: docker.coredns
+#       trigger: true
+#   - task: bump
+#     file: ci/pipelines/cf-operator/tasks/create-coredns-pr.yml
+#     params:
+#       USERNAME: ((github.user))
+#       PASSWORD: ((github.password))
+#       coredns_repo: ((coredns-repo))

--- a/pipelines/cf-operator/pipeline.yml
+++ b/pipelines/cf-operator/pipeline.yml
@@ -31,7 +31,7 @@ resources:
   type: docker-image
   check_every: 48h
   source:
-    repository: registry.opensuse.org/cloud/platform/quarks/images/images/coredns
+    repository: ((coredns-repo))
 - name: s3.cf-operator
   type: s3
   source:
@@ -252,3 +252,4 @@ jobs:
     params:
       USERNAME: ((github.user))
       PASSWORD: ((github.password))
+      coredns_repo: ((coredns-repo))

--- a/pipelines/cf-operator/tasks/create-coredns-pr.sh
+++ b/pipelines/cf-operator/tasks/create-coredns-pr.sh
@@ -2,11 +2,12 @@
 
 set -e
 
+: "${coredns_repo:?}"
 
 # find new coredns version
 pushd docker.coredns
 version=$(cat digest)
-url="registry.opensuse.org/cloud/platform/quarks/images/images/coredns@$version"
+url="$coredns_repo@$version"
 rpmversion=$(chroot rootfs rpm -q coredns)
 popd
 

--- a/pipelines/cf-operator/vars.yml
+++ b/pipelines/cf-operator/vars.yml
@@ -8,3 +8,4 @@ ghcr-repository: ghcr.io/cloudfoundry-incubator/quarks-operator
 storageclass: hostpath-containerization
 goproxy: http://10.72.144.202:30080,https://proxy.golang.org
 ibmcloud-cluster: pebbles01
+coredns-repo: docker.io/cfcontainerization/coredns


### PR DESCRIPTION
There is a problem with the CAP release tool, since we only get a SHA
(not a tag) from OBS: https://jira.suse.com/browse/CAP-1598

Apparently registry.opensuse.org cannot store multiple versions, so the
SHA would disappear once a new version is pushed. All
registry.opensuse.org images have to be copied elsewhere.



This disables the create-pr task for coredns updates:

* the obs project doesn't seem to update the os image
* the cap release-tool doesn't understand sha references
* the dockerhub repo for coredns on SLE doesn't have a latest tag and can't be monitored with the Concourse dockerhub resource


[#175116396](https://www.pivotaltracker.com/story/show/175116396)